### PR TITLE
Correct pic orientation in crop view

### DIFF
--- a/photo-chooser/src/main/java/cz/ackee/choosephoto/utils/GalleryUtils.java
+++ b/photo-chooser/src/main/java/cz/ackee/choosephoto/utils/GalleryUtils.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
+import android.media.ExifInterface;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -215,6 +216,16 @@ public class GalleryUtils {
         final Uri BASE_URI = Uri.parse("content://" + AUTHORITY);
 
         return Uri.withAppendedPath(BASE_URI, "profile");
+    }
+
+    public static int getRotationDegrees(ExifInterface exif) {
+        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0);
+        switch (orientation) {
+            case ExifInterface.ORIENTATION_ROTATE_90: return 90;
+            case ExifInterface.ORIENTATION_ROTATE_180: return 180;
+            case ExifInterface.ORIENTATION_ROTATE_270: return 270;
+            default: return 0;
+        }
     }
 
     private static boolean storeImageFromUri(Context ctx, Uri remoteUri, Uri myUri) {


### PR DESCRIPTION
Shows correct picture orientation in CropFragment.

Storing images with correct orientation?
Decoding bitmaps and rewriting files takes a while, which is ok if crop is not enabled...
If crop is enabled, rewriting file will take time, therefore CropFragment is displayed with a delay which is frustrating for a user...
Also, ExifInterface(is: InputStream) from support.media package does not seem work properly as it always returns 0 degree orientation...

Unfortunatelly, it seems like we will have to rotate images outside of photochooser...