### PR TITLE
Feature/file provider

### DIFF
--- a/.idea/markdown-navigator/profiles_settings.xml
+++ b/.idea/markdown-navigator/profiles_settings.xml
@@ -1,3 +1,3 @@
 <component name="MarkdownNavigator.ProfileManager">
-  <settings default="" />
+  <settings default="" pdf-export="" />
 </component>

--- a/README.md
+++ b/README.md
@@ -7,63 +7,45 @@ This library allows to choose pictures from system gallery or from camera, save 
 
 Based on RxJava2
 ## Usage
-
-### Android Manifest
-Its important to add this to your manifest. Library uses `FileProvider` and its specification needs to be in your `AndroidManifest.xml`
-
-```xml
-<provider
-    android:name="android.support.v4.content.FileProvider"
-    android:authorities="${applicationId}.choose_photo"
-    android:exported="false"
-    android:grantUriPermissions="true">
-    <meta-data
-        android:name="android.support.FILE_PROVIDER_PATHS"
-        android:resource="@xml/file_provider_path"/>
-</provider>
-```
-
-And that should be it. Do not change anything here, please.
-
-### Code
 Core class of library is `ChoosePhotoHelper`. First you must create instance of this helper
 ```kotlin
-val choosePhotoHelper = ChoosePhotoHelper(this, object : ChoosePhotoHelper.OnPhotoPickedListener() {
-
+val choosePhotoHelper = ChoosePhotoHelper(this,
+    object : ChoosePhotoHelper.OnPhotoPickedListener() {
         override fun onPhotoPicked(fileObservable: Observable<File>) {
-        //listener called when photo is available
+            //listener called when photo is available
         }
-    }, object : ChoosePhotoHelper.OnPhotoCopyingListener() {
+    },
+    object : ChoosePhotoHelper.OnPhotoCopyingListener() {
     
         override fun photoCopying(isCopying: Boolean) {
-        // called when copying of photo is in progress.
-        // When picture is in some remote location (i.e. google drive), downloading and copying can take some time
+            // called when copying of photo is in progress.
+            // When picture is in some remote location (i.e. google drive), downloading and copying can take some time
         }
     })
 ```
 
 When you want to show dialog with camera/gallery options, you call
 ```kotlin
-choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID).show(getSupportFragmentManager())
+choosePhotoHelper.getChoosePhotoDialogBuilder().show(getSupportFragmentManager())
 ```
 It is important to pass application id (package name) because it needs to match with the one in manifest.
 
 
 The crop functionality is disabled by default, you can enable it by passing attribute to `getChoosePhotoDialogBuilder` like
 ```kotlin
-choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true).show(getSupportFragmentManager())
+choosePhotoHelper.getChoosePhotoDialogBuilder(true).show(getSupportFragmentManager())
 ```
 
 Crop screen has Done button, that is tinted with colorPrimary from your theme. If you want to pass custom color, there is another overloaded method `getChoosePhotoDialogBuilder`
 
 ```kotlin
-choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true, Color.BLUE).show(getSupportFragmentManager())
+choosePhotoHelper.getChoosePhotoDialogBuilder(true, Color.BLUE).show(getSupportFragmentManager())
 ```
 
 If you have UI that requires to call directly camera/gallery without prompt dialog, you can call
 ```kotlin
-choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true).showCamera(getActivity())
-choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true).showGallery(getActivity())
+choosePhotoHelper.getChoosePhotoDialogBuilder(true).showCamera(getActivity())
+choosePhotoHelper.getChoosePhotoDialogBuilder(true).showGallery(getActivity())
 ```
 but you need to handle permissions request for yourself.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,27 +1,22 @@
 <manifest package="com.ackee.photo_chooser"
           xmlns:android="http://schemas.android.com/apk/res/android">
+
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <provider
-            android:name="android.support.v4.content.FileProvider"
-            android:authorities="${applicationId}.choose_photo"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_provider_path"/>
-        </provider>
+
         <activity android:name="cz.ackee.choosephoto.sample.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/cz/ackee/choosephoto/sample/MainActivity.java
+++ b/app/src/main/java/cz/ackee/choosephoto/sample/MainActivity.java
@@ -9,7 +9,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.ImageView;
 
-import com.ackee.photo_chooser.BuildConfig;
 import com.ackee.photo_chooser.R;
 
 import java.io.File;
@@ -27,7 +26,6 @@ import io.reactivex.functions.Function;
 public class MainActivity extends AppCompatActivity {
     public static final String TAG = MainActivity.class.getName();
     private ChoosePhotoHelper choosePhotoHelper;
-
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -62,25 +60,25 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.btn_choose_photo).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID).show(getSupportFragmentManager());
+                choosePhotoHelper.getChoosePhotoDialogBuilder().show(getSupportFragmentManager());
             }
         });
         findViewById(R.id.btn_choose_photo_with_crop).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true).show(getSupportFragmentManager());
+                choosePhotoHelper.getChoosePhotoDialogBuilder(true).show(getSupportFragmentManager());
             }
         });
         findViewById(R.id.btn_choose_photo_with_crop_wide).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true, getResources().getColor(R.color.colorPrimary), 1920, 1080).show(getSupportFragmentManager());
+                choosePhotoHelper.getChoosePhotoDialogBuilder(true, getResources().getColor(R.color.colorPrimary), 1920, 1080).show(getSupportFragmentManager());
             }
         });
         findViewById(R.id.btn_choose_photo_custom_dialog).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true)
+                choosePhotoHelper.getChoosePhotoDialogBuilder(true)
                         .setPickPhotoString("Gallery selection")
                         .setTakePhotoString("Selfie Time!")
                         .setFileName("myselfie.jpg")
@@ -90,7 +88,7 @@ public class MainActivity extends AppCompatActivity {
         findViewById(R.id.btn_take_picture_directly).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                choosePhotoHelper.getChoosePhotoDialogBuilder(BuildConfig.APPLICATION_ID, true).showCamera(MainActivity.this);
+                choosePhotoHelper.getChoosePhotoDialogBuilder(true).showCamera(MainActivity.this);
             }
         });
     }

--- a/photo-chooser/src/main/AndroidManifest.xml
+++ b/photo-chooser/src/main/AndroidManifest.xml
@@ -5,9 +5,20 @@
     <application
         android:allowBackup="false">
 
-        <activity android:name=".CropPhotoActivity"
-                  android:theme="@style/Theme.AppCompat.Light.NoActionBar"
-        />
+        <activity
+            android:name=".CropPhotoActivity"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
+
+        <provider
+            android:name=".ChoosePhotoFileProvider"
+            android:authorities="${applicationId}.choose_photo"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_path"/>
+        </provider>
+
     </application>
 
 </manifest>

--- a/photo-chooser/src/main/java/cz/ackee/choosephoto/ChoosePhotoDialogFragment.java
+++ b/photo-chooser/src/main/java/cz/ackee/choosephoto/ChoosePhotoDialogFragment.java
@@ -103,15 +103,13 @@ public class ChoosePhotoDialogFragment extends DialogFragment {
 
         private final Context ctx;
         private final DialogBuiltCallback callback;
-        private final String authority;
         private String pickPhotoString = "Pick photo";
         private String takePhotoString = "Take photo";
         private String fileName = "temp.jpg";
 
-        public Builder(Context ctx, String authority, DialogBuiltCallback callback) {
+        public Builder(Context ctx, DialogBuiltCallback callback) {
             this.ctx = ctx;
             this.callback = callback;
-            this.authority = authority;
         }
 
         public Builder setTakePhotoString(@StringRes int takePhoto) {
@@ -151,7 +149,7 @@ public class ChoosePhotoDialogFragment extends DialogFragment {
         }
 
         private Uri buildUri() {
-            return FileUtils.getUriForFilename(ctx, authority, fileName);
+            return FileUtils.getUriForFilename(ctx, ctx.getPackageName() + ".choose_photo", fileName);
         }
 
         private static void showCamera(Activity ac, Uri uri) {

--- a/photo-chooser/src/main/java/cz/ackee/choosephoto/ChoosePhotoFileProvider.java
+++ b/photo-chooser/src/main/java/cz/ackee/choosephoto/ChoosePhotoFileProvider.java
@@ -1,0 +1,14 @@
+package cz.ackee.choosephoto;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * This file provider defines directory in which app can store photos. Referencing
+ * multiple file providers in androidManifest where each define {@link FileProvider} as its
+ * implementation class leads to compile errors. Simply subclassing and referencing the subclass
+ * is enough to fix the problem.
+ *
+ * Defined by [res/xml/file_provider_paths.xml]
+ */
+public class ChoosePhotoFileProvider extends FileProvider {
+}

--- a/photo-chooser/src/main/java/cz/ackee/choosephoto/ChoosePhotoHelper.java
+++ b/photo-chooser/src/main/java/cz/ackee/choosephoto/ChoosePhotoHelper.java
@@ -61,46 +61,70 @@ public class ChoosePhotoHelper implements ChoosePhotoDialogFragment.DialogBuiltC
     }
 
     /**
-     * Returns builder for creating ChoosePhotoDialogFragment
-     *
-     * @param applicationId application id (package name)
+     * Deprecated. Use method without applicationId parameter.
      */
+    @Deprecated
     public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(String applicationId, boolean withCrop) {
-        this.withCrop = withCrop;
-        return new ChoosePhotoDialogFragment.Builder(ctx, applicationId + ".choose_photo", this);
+        return getChoosePhotoDialogBuilder(withCrop);
     }
 
     /**
      * Returns builder for creating ChoosePhotoDialogFragment
-     *
-     * @param applicationId application id (package name)
      */
+    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(boolean withCrop) {
+        this.withCrop = withCrop;
+        return new ChoosePhotoDialogFragment.Builder(ctx, this);
+    }
+
+    /**
+     * Deprecated. Use method without applicationId parameter.
+     */
+    @Deprecated
     public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(String applicationId, boolean withCrop, int tintColor) {
+        return getChoosePhotoDialogBuilder(withCrop, tintColor);
+    }
+
+    /**
+     * Returns builder for creating ChoosePhotoDialogFragment
+     */
+    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(boolean withCrop, int tintColor) {
         this.withCrop = withCrop;
         this.tintColor = tintColor;
-        return new ChoosePhotoDialogFragment.Builder(ctx, applicationId + ".choose_photo", this);
+        return new ChoosePhotoDialogFragment.Builder(ctx, this);
+    }
+
+    /**
+     * Deprecated. Use method without applicationId parameter.
+     */
+    @Deprecated
+    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(String applicationId, boolean withCrop, int tintColor, Integer maxWidth, Integer maxHeight) {
+        return getChoosePhotoDialogBuilder(withCrop, tintColor, maxWidth, maxHeight);
     }
 
     /**
      * Returns builder for creating ChoosePhotoDialogFragment
-     *
-     * @param applicationId application id (package name)
      */
-    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(String applicationId, boolean withCrop, int tintColor, Integer maxWidth, Integer maxHeight) {
+    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(boolean withCrop, int tintColor, Integer maxWidth, Integer maxHeight) {
         this.withCrop = withCrop;
         this.tintColor = tintColor;
         this.maxWidth = maxWidth;
         this.maxHeight = maxHeight;
-        return new ChoosePhotoDialogFragment.Builder(ctx, applicationId + ".choose_photo", this);
+        return new ChoosePhotoDialogFragment.Builder(ctx, this);
+    }
+
+    /**
+     * Deprecated. Use method without applicationId parameter.
+     */
+    @Deprecated
+    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(String applicationId) {
+        return getChoosePhotoDialogBuilder();
     }
 
     /**
      * Returns builder for creating ChoosePhotoDialogFragment
-     *
-     * @param applicationId application id (package name)
      */
-    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder(String applicationId) {
-        return getChoosePhotoDialogBuilder(applicationId, false);
+    public ChoosePhotoDialogFragment.Builder getChoosePhotoDialogBuilder() {
+        return getChoosePhotoDialogBuilder(false);
     }
 
     /**


### PR DESCRIPTION
Removed redundant `applicationId` from all `Builder` methods. It can be retrieved from `String Context.getPackageName()`.

Moved FileProvider definition from app to library AndroidManifest. Users now don't have to define it in their app anymore. Removed AndroidManifest section from the readme.

Furthermore defined `ChoosePhotoFileProvider` subclass as it caused problems when AndroidManifest (merged) defined multiple FileProviders where 2 or more of them used `FileProvider` as their implementation class.